### PR TITLE
Add the ability to use streams as the input instead of just arrays

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -303,7 +303,7 @@
                     return reject(validation.error);
                 }
 
-                var results = Rx.Observable.fromArray(items);
+                var results = Array.isArray(items) ? Rx.Observable.from(items) : items;
                 if (aggregation.$skip) {
                     results = results.skip(aggregation.$skip);
                 }
@@ -341,7 +341,9 @@
                     return reject(validation.error);
                 }
 
-                var results = internals.filter(Rx.Observable.fromArray(items), filter);
+                // If we didn't get an array, let's make the assumption that it is an observable sequence.
+                // Since this is compatible with anything as long as it provides the necessary method.
+                var results = internals.filter(Array.isArray(items) ? Rx.Observable.from(items) : items, filter);
 
                 if (options.stream) {
                     resolve(results);

--- a/test/aggregate.js
+++ b/test/aggregate.js
@@ -49,9 +49,52 @@ describe('aggregate()', function () {
         }).catch(done);
     });
 
+    it('should be able to use a stream as the input', function (done) {
+
+        var Rx = require('rx');
+
+        Bloc.aggregate(Rx.Observable.from(testData), null).then(function (results) {
+
+            expect(results[0]).to.equal(testData[0]);
+            expect(results[1]).to.equal(testData[1]);
+            expect(results[2]).to.equal(testData[2]);
+            expect(results[3]).to.equal(testData[3]);
+            expect(results[4]).to.equal(testData[4]);
+            expect(results[5]).to.equal(testData[5]);
+            expect(results[6]).to.equal(testData[6]);
+            expect(results.length).to.equal(6);
+            done();
+        }, done).catch(done);
+    });
+
     it('should send back the stream instead of the results when requested', function (done) {
 
         Bloc.aggregate(testData, null, {stream: true}).then(function (stream) {
+
+            stream
+                .toArray()
+                .subscribe(
+                function (results) {
+
+                    expect(results[0]).to.equal(testData[0]);
+                    expect(results[1]).to.equal(testData[1]);
+                    expect(results[2]).to.equal(testData[2]);
+                    expect(results[3]).to.equal(testData[3]);
+                    expect(results[4]).to.equal(testData[4]);
+                    expect(results[5]).to.equal(testData[5]);
+                    expect(results[6]).to.equal(testData[6]);
+                    expect(results.length).to.equal(6);
+                }, done);
+
+            done();
+        }, done).catch(done);
+    });
+
+    it('should be able to use a stream as the input and get a stream as the output', function (done) {
+
+        var Rx = require('rx');
+
+        Bloc.aggregate(Rx.Observable.from(testData), null, {stream: true}).then(function (stream) {
 
             stream
                 .toArray()

--- a/test/filter.js
+++ b/test/filter.js
@@ -87,9 +87,42 @@ describe('filter()', function () {
         }, done).catch(done);
     });
 
+    it('should be able to use a stream as the input', function (done) {
+
+        var Rx = require('rx');
+
+        Bloc.filter(Rx.Observable.from(testData), {}).then(function (results) {
+
+            expect(results[0]).to.equal(testData[0]);
+            expect(results[1]).to.equal(testData[1]);
+            expect(results.length).to.equal(2);
+            done();
+        }, done).catch(done);
+    });
+
     it('should send back the stream instead of the results when requested', function (done) {
 
         Bloc.filter(testData, {}, {stream: true}).then(function (stream) {
+
+            stream
+                .toArray()
+                .subscribe(
+                function (results) {
+
+                    expect(results[0]).to.equal(testData[0]);
+                    expect(results[1]).to.equal(testData[1]);
+                    expect(results.length).to.equal(2);
+                }, done);
+
+            done();
+        }, done).catch(done);
+    });
+
+    it('should be able to use a stream as the input and get a stream as the output', function (done) {
+
+        var Rx = require('rx');
+
+        Bloc.filter(Rx.Observable.from(testData), {}, {stream: true}).then(function (stream) {
 
             stream
                 .toArray()
@@ -319,7 +352,7 @@ describe('filter()', function () {
 
             Bloc.filter(testData, {
                 name: {
-                    $where: function(value) {
+                    $where: function (value) {
 
                         return /^Anthony/.test(value);
                     }
@@ -863,7 +896,7 @@ describe('filter()', function () {
                 Bloc.filter(testData, {
                     name: {
                         $not: {
-                            $where: function(value) {
+                            $where: function (value) {
 
                                 return /^Anthony/.test(value);
                             }


### PR DESCRIPTION
This PR adds the ability for streams to be passed as the input for filtering and aggregation. This way a stream could be kept open and processed as data comes in.
